### PR TITLE
Decouple setup.py and requirements.txt for compatibility with pip >= 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,9 @@ A python API to consume transit data from http://511.org.
 
 from setuptools import setup
 from pip.req import parse_requirements
- 
-install_reqs = parse_requirements("requirements.txt")
-requirements = [str(ir.req) for ir in install_reqs]
- 
+
+requirements = ("requests==2.5.1", )
+
 setup(
     name='fiveoneone',
     version='0.3.dev0',


### PR DESCRIPTION
Hi there!

First of all, I'd like to say a big thanks for 511-transit! I'd been having to cook up my own one-off muni API consumers for projects here and there, and I'm pleased that you decided to publish yours! It's been useful for my transit-related projects.

I ran into an issue trying to use your library with a newer version of pip, however. While everything works great on my macbook (pip 1.3.1) and my Ubuntu servers (pip 1.5.4), when trying to use tox (which uses a newer virtualenv, which means a newer version of pip) with my project, I got the following exception:

```
TypeError: parse_requirements() missing 1 required keyword argument: 'session'
```

This patch decouples setup.py and requirements.txt. While linking the two together is convenient, this code uses an interface exposed by pip which is not guaranteed to be stable, and broke starting in pip 6. Since 511-transit only has a single dependency at this time, it might be more desirable to target newer versions of pip than to worry about duplicating dependency lists.

This patch fixes setup.py in newer pip versions (6.0 and newer). I tested on my macbook by doing the following (using virtualenvwrapper):

```
$ mkvirtualenv fiveoneone ; pip --version && python setup.py --requires && pip install --upgrade pip && pip --version && python setup.py --requires
New python executable in fiveoneone/bin/python
Installing setuptools............done.
Installing pip...............done.
pip 1.3.1 from /Users/fhats/.virtualenvs/fiveoneone/lib/python2.7/site-packages/pip-1.3.1-py2.7.egg (python 2.7)

Downloading/unpacking pip from https://pypi.python.org/packages/source/p/pip/pip-7.1.0.tar.gz#md5=d935ee9146074b1d3f26c5f0acfd120e
  Downloading pip-7.1.0.tar.gz (1.0MB): 1.0MB downloaded
  Running setup.py egg_info for package pip

    warning: no previously-included files found matching '.coveragerc'
    warning: no previously-included files found matching '.mailmap'
    warning: no previously-included files found matching '.travis.yml'
    warning: no previously-included files found matching 'pip/_vendor/Makefile'
    warning: no previously-included files found matching 'tox.ini'
    warning: no previously-included files found matching 'dev-requirements.txt'
    no previously-included directories found matching '.travis'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'contrib'
    no previously-included directories found matching 'tasks'
    no previously-included directories found matching 'tests'
Installing collected packages: pip
  Found existing installation: pip 1.3.1
    Uninstalling pip:
      Successfully uninstalled pip
  Running setup.py install for pip

    warning: no previously-included files found matching '.coveragerc'
    warning: no previously-included files found matching '.mailmap'
    warning: no previously-included files found matching '.travis.yml'
    warning: no previously-included files found matching 'pip/_vendor/Makefile'
    warning: no previously-included files found matching 'tox.ini'
    warning: no previously-included files found matching 'dev-requirements.txt'
    no previously-included directories found matching '.travis'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'contrib'
    no previously-included directories found matching 'tasks'
    no previously-included directories found matching 'tests'
    Installing pip script to /Users/fhats/.virtualenvs/fiveoneone/bin
    Installing pip2.7 script to /Users/fhats/.virtualenvs/fiveoneone/bin
    Installing pip2 script to /Users/fhats/.virtualenvs/fiveoneone/bin
Successfully installed pip
Cleaning up...
pip 7.1.0 from /Users/fhats/.virtualenvs/fiveoneone/lib/python2.7/site-packages (python 2.7)
```

Here's the same command on master, where this breaks:

```
$ mkvirtualenv fiveoneone ; pip --version && python setup.py --requires && pip install --upgrade pip && pip --version && python setup.py --requires
New python executable in fiveoneone/bin/python
Installing setuptools............done.
Installing pip...............done.
pip 1.3.1 from /Users/fhats/.virtualenvs/fiveoneone/lib/python2.7/site-packages/pip-1.3.1-py2.7.egg (python 2.7)

Downloading/unpacking pip from https://pypi.python.org/packages/source/p/pip/pip-7.1.0.tar.gz#md5=d935ee9146074b1d3f26c5f0acfd120e
  Downloading pip-7.1.0.tar.gz (1.0MB): 1.0MB downloaded
  Running setup.py egg_info for package pip

    warning: no previously-included files found matching '.coveragerc'
    warning: no previously-included files found matching '.mailmap'
    warning: no previously-included files found matching '.travis.yml'
    warning: no previously-included files found matching 'pip/_vendor/Makefile'
    warning: no previously-included files found matching 'tox.ini'
    warning: no previously-included files found matching 'dev-requirements.txt'
    no previously-included directories found matching '.travis'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'contrib'
    no previously-included directories found matching 'tasks'
    no previously-included directories found matching 'tests'
Installing collected packages: pip
  Found existing installation: pip 1.3.1
    Uninstalling pip:
      Successfully uninstalled pip
  Running setup.py install for pip

    warning: no previously-included files found matching '.coveragerc'
    warning: no previously-included files found matching '.mailmap'
    warning: no previously-included files found matching '.travis.yml'
    warning: no previously-included files found matching 'pip/_vendor/Makefile'
    warning: no previously-included files found matching 'tox.ini'
    warning: no previously-included files found matching 'dev-requirements.txt'
    no previously-included directories found matching '.travis'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'contrib'
    no previously-included directories found matching 'tasks'
    no previously-included directories found matching 'tests'
    Installing pip script to /Users/fhats/.virtualenvs/fiveoneone/bin
    Installing pip2.7 script to /Users/fhats/.virtualenvs/fiveoneone/bin
    Installing pip2 script to /Users/fhats/.virtualenvs/fiveoneone/bin
Successfully installed pip
Cleaning up...
pip 7.1.0 from /Users/fhats/.virtualenvs/fiveoneone/lib/python2.7/site-packages (python 2.7)
Traceback (most recent call last):
  File "setup.py", line 12, in <module>
    requirements = [str(ir.req) for ir in install_reqs]
  File "/Users/fhats/.virtualenvs/fiveoneone/lib/python2.7/site-packages/pip/req/req_file.py", line 72, in parse_requirements
    "parse_requirements() missing 1 required keyword argument: "
TypeError: parse_requirements() missing 1 required keyword argument: 'session'
```

More info:
- https://stackoverflow.com/questions/27869152/heroku-typeerror-parse-requirements-missing-1-required-keyword-argument-ses
- https://caremad.io/2013/07/setup-vs-requirement/
